### PR TITLE
condition

### DIFF
--- a/libs/xml-operations/include/xml_operations.h
+++ b/libs/xml-operations/include/xml_operations.h
@@ -49,6 +49,7 @@ class XmlOperation
     pugi::xml_node node_;
 
     bool           skip_ = false;
+    std::string    condition_;
 
     std::string mod_name_;
     fs::path    game_path_;
@@ -83,4 +84,6 @@ class XmlOperation
 
     pugi::xpath_node_set ReadGuidNodes(std::shared_ptr<pugi::xml_document> doc);
     pugi::xpath_node_set ReadTemplateNodes(std::shared_ptr<pugi::xml_document> doc);
+
+    bool CheckCondition(std::shared_ptr<pugi::xml_document> doc);
 };

--- a/tests/xml/condition/condition_match.json
+++ b/tests/xml/condition/condition_match.json
@@ -1,0 +1,8 @@
+{
+    "name": "Condition Match",
+    "expected": [
+        "/Test/Node[Meow='5']",
+        "/Test/Node[Meow='3']",
+        "!/Test/Node[Meow='2']"
+    ]
+}

--- a/tests/xml/condition/condition_match_input.xml
+++ b/tests/xml/condition/condition_match_input.xml
@@ -1,0 +1,6 @@
+<Test>
+    <Node>
+        <Meow>5</Meow>
+        <Meow>4</Meow>
+    </Node>
+</Test>

--- a/tests/xml/condition/condition_match_patch.xml
+++ b/tests/xml/condition/condition_match_patch.xml
@@ -1,0 +1,8 @@
+<ModOps>
+<ModOp Type="add" Path="/Test/Node[Meow='5']" Condition="/Test/Node[Meow='4']">
+    <Meow>3</Meow>
+</ModOp>
+<ModOp Type="add" Path="/Test/Node[Meow='5']" Condition="/Test/Node[Meow='1']">
+    <Meow>2</Meow>
+</ModOp>
+</ModOps>

--- a/tests/xml/condition/condition_no_match.json
+++ b/tests/xml/condition/condition_no_match.json
@@ -1,0 +1,8 @@
+{
+    "name": "Condition No Match",
+    "expected": [
+        "/Test/Node[Meow='5']",
+        "/Test/Node[Meow='3']",
+        "!/Test/Node[Meow='2']"
+    ]
+}

--- a/tests/xml/condition/condition_no_match_input.xml
+++ b/tests/xml/condition/condition_no_match_input.xml
@@ -1,0 +1,6 @@
+<Test>
+    <Node>
+        <Meow>5</Meow>
+        <Meow>4</Meow>
+    </Node>
+</Test>

--- a/tests/xml/condition/condition_no_match_patch.xml
+++ b/tests/xml/condition/condition_no_match_patch.xml
@@ -1,0 +1,8 @@
+<ModOps>
+<ModOp Type="add" Path="/Test/Node[Meow='5']" Condition="!/Test/Node[Meow='1']">
+    <Meow>3</Meow>
+</ModOp>
+<ModOp Type="add" Path="/Test/Node[Meow='5']" Condition="!/Test/Node[Meow='4']">
+    <Meow>2</Meow>
+</ModOp>
+</ModOps>


### PR DESCRIPTION
ModOps will only execute on match.
`!` can be used to only execute on no match.