### PR TITLE
fix(xml-ops): prevent buffer overflow when parsing Template Name

### DIFF
--- a/libs/xml-operations/src/xml_operations.cc
+++ b/libs/xml-operations/src/xml_operations.cc
@@ -356,7 +356,7 @@ void XmlLookup::ReadPath(std::string prop_path,
 
     if (temp.empty()) {
         char g[256];
-        if (sscanf(prop_path.c_str(), "//Template[Name='%s']", g) > 0) {
+        if (sscanf(prop_path.c_str(), "//Template[Name='%255[^']']", g) == 1) {
             if (std::string("//Template[Name='" + std::string(g) + "']") == prop_path) {
                 temp                   = g;
                 template_              = g;


### PR DESCRIPTION
This patch bounds parsing of Template Name by switching from "%s" to a quote-delimited scanset ("%255[^']") and checking for exactly one match. This avoids copying arbitrary-length data into a 256-byte stack buffer while preserving behavior for valid inputs.

- Risk: crash/memory corruption
- Area: xml-ops / Template Name parsing
- Backward compatibility: no change for valid inputs